### PR TITLE
Remove leftover random import

### DIFF
--- a/template.py
+++ b/template.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from random import random
 import uuid
 
 


### PR DESCRIPTION
## Summary
- cleanup template module

## Testing
- `pytest -q` *(fails: AttributeError: module 'tests.streamlit_stub' has no attribute 'errors')*

------
https://chatgpt.com/codex/tasks/task_e_685e1356e77c832185adfb6fb6803c21