### PR TITLE
Fix test linter warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,17 @@ df_book = df_books[df_books["ISBN"] == st.session_state["ISBN"]]
 
 
 def jaccard_similarity(user_ids_isbn_a, user_ids_isbn_b):
+    """Return Jaccard similarity of two ISBN user ID lists.
+
+    Parameters
+    ----------
+    user_ids_isbn_a : iterable
+    user_ids_isbn_b : iterable
+
+    Returns
+    -------
+    float
+    """
 
     set_isbn_a = set(user_ids_isbn_a)
     set_isbn_b = set(user_ids_isbn_b)

--- a/tests/streamlit_stub.py
+++ b/tests/streamlit_stub.py
@@ -19,63 +19,45 @@ sidebar = Sidebar()
 # capture error messages for tests
 errors = []
 
-
-
-
 def set_page_config(*args, **kwargs):
     pass
-
-
 
 def info(*args, **kwargs):
     pass
 
-
 def error(message):
     errors.append(message)
-
 
 def stop():
     raise RuntimeError("stop")
 
-
 def button(*args, **kwargs):
     return False
-
 
 class Placeholder:
     def empty(self):
         pass
 
-
 def empty(*args, **kwargs):
     return Placeholder()
-
 
 def columns(n):
     return [Sidebar() for _ in range(n)]
 
-
 def image(*args, **kwargs):
     pass
-
 
 def title(*args, **kwargs):
     pass
 
-
 def markdown(*args, **kwargs):
     pass
-
 
 def caption(*args, **kwargs):
     pass
 
-
 def subheader(*args, **kwargs):
     pass
 
-
 def write(*args, **kwargs):
     pass
-

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -1,7 +1,9 @@
 import sys
+import importlib
 import tests.streamlit_stub as st
+
 sys.modules["streamlit"] = st
-import template as t
+t = importlib.import_module("template")
 
 
 def test_no_duplicate_addition():

--- a/tests/test_missing_files.py
+++ b/tests/test_missing_files.py
@@ -13,6 +13,7 @@ def test_missing_datasets():
         del sys.modules['app']
 
     pd_stub = types.ModuleType('pandas')
+
     def raise_fn(*args, **kwargs):
         raise FileNotFoundError('missing')
     pd_stub.read_csv = raise_fn


### PR DESCRIPTION
## Summary
- condense extra blank lines in `streamlit_stub`
- reorganize `test_friends` imports using `importlib`
- add blank line before nested function in `test_missing_files`
- shorten `jaccard_similarity` docstring

## Testing
- `pytest -q`
- ❌ `flake8` *(failed to run: `flake8: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e19cb0920832194e2da8bd23f44d8